### PR TITLE
Added JPA repository interfaces

### DIFF
--- a/src/main/java/org/trustworthyreviews/repository/ProductRepository.java
+++ b/src/main/java/org/trustworthyreviews/repository/ProductRepository.java
@@ -1,0 +1,22 @@
+package org.trustworthyreviews.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+import org.trustworthyreviews.Product;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, UUID>, JpaSpecificationExecutor<Product> {
+
+    Optional<Product> findByName(String name);
+
+    List<Product> findByCategory(String category);
+
+    Page<Product> findAllByCategoryOrderByCreatedAtDesc(String category, Pageable pageable);
+}

--- a/src/main/java/org/trustworthyreviews/repository/ReviewRepository.java
+++ b/src/main/java/org/trustworthyreviews/repository/ReviewRepository.java
@@ -1,0 +1,22 @@
+package org.trustworthyreviews.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+import org.trustworthyreviews.Review;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, UUID>, JpaSpecificationExecutor<Review> {
+    List<Review> findByProductIdOrderByCreatedAtDesc(UUID productId);
+
+    Page<Review> findByProductId(UUID productId, Pageable pageable);
+
+    long countByProductId(UUID productId);
+
+    List<Review> findByAuthorId(UUID authorId);
+}

--- a/src/main/java/org/trustworthyreviews/repository/UserRepository.java
+++ b/src/main/java/org/trustworthyreviews/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package org.trustworthyreviews.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+import org.trustworthyreviews.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID>, JpaSpecificationExecutor<User> {
+    Optional<User> findByUserName(String userName);
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}


### PR DESCRIPTION
Added 3 interfaces for the JPA repos; respectively:
 - public interface ProductRepository extends JpaRepository<Product, UUID>, JpaSpecificationExecutor<Product> {}
 - public interface ReviewRepository extends JpaRepository<Review, UUID>, JpaSpecificationExecutor<Review> {}
 - public interface UserRepository extends JpaRepository<User, UUID>, JpaSpecificationExecutor<User> {}

Each with derived query methods that will or may be required.