### PR TITLE
Updated application.properties to show binding errors in API response…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 logging.level.org.hibernate.SQL=DEBUG
 
+server.error.include-message=always
+server.error.include-binding-errors=always
+


### PR DESCRIPTION
API responses when running the jar were missing the binding errors used by my frontend. Updating the application properties to tell spring boot to enable binding errors on production builds.

Closes #65 